### PR TITLE
fix c++ compilation

### DIFF
--- a/pocketmod.h
+++ b/pocketmod.h
@@ -145,7 +145,7 @@ static int _pocketmod_clamp_volume(int x)
 /* Zero out a block of memory */
 static void _pocketmod_zero(void *data, int size)
 {
-    char *byte = data, *end = byte + size;
+    char *byte = (char*) data, *end = byte + size;
     while (byte != end) { *byte++ = 0; }
 }
 


### PR DESCRIPTION
Currently it's not possible to use pocketmod with `#define POCKETMOD_IMPLEMENTATION` from a c++ file, because of one missing void*->char* cast, which is implicit in c but not in c++. This PR fixes that.